### PR TITLE
Fix unspecified behavior:

### DIFF
--- a/fd2pragma.c
+++ b/fd2pragma.c
@@ -11667,7 +11667,7 @@ static uint32 CreateXML(void)
   "<!DOCTYPE library SYSTEM \"library.dtd\">\n"
   "<library name=\"%s\" basename=\"%s\" openname=\"%s\"",
   ShortBaseName, BaseName, GetLibraryName());
-  if(GetBaseTypeLib() != "Library")
+  if(strcmp(GetBaseTypeLib(), "Library") != 0)
     DoOutput(" basetype=\"%s\"", GetBaseTypeLib());
   DoOutput(">\n");
   for(inc = (struct Include *) Includes.First; inc;


### PR DESCRIPTION
fd2pragma.c: In function 'CreateXML':
fd2pragma.c:11670:23: warning: comparison with string literal results in unspecified behavior [-Waddress]
